### PR TITLE
La facturación de las órdenes de ventas requieren que el diccionario

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,3 +3,4 @@
 import l10n_co_tax_extension
 import ir_sequence
 import sale
+import sale_make_invoice_advance

--- a/models/l10n_co_tax_extension.py
+++ b/models/l10n_co_tax_extension.py
@@ -77,7 +77,7 @@ class AccountInvoice(models.Model):
     resolution_number_from = fields.Integer("")
     resolution_number_to = fields.Integer("")
 
-    # Calculate withholding tax and (new) total amount
+    # Calculate withholding tax and (new) total amount 
 
     @api.one
     @api.depends('invoice_line_ids.price_subtotal', 'tax_line_ids.amount', 'currency_id', 'company_id')

--- a/models/sale_make_invoice_advance.py
+++ b/models/sale_make_invoice_advance.py
@@ -1,0 +1,68 @@
+import time
+
+from openerp import api, fields, models, _
+import openerp.addons.decimal_precision as dp
+from openerp.exceptions import UserError
+
+class SaleAdvancePaymentInv(models.TransientModel):
+    _name = "sale.advance.payment.inv"
+    _description = "Sales Advance Payment Invoice"
+    _inherit = "sale.advance.payment.inv"
+
+    @api.multi
+    def _create_invoice(self, order, so_line, amount):
+        inv_obj = self.env['account.invoice']
+        ir_property_obj = self.env['ir.property']
+
+        account_id = False
+        if self.product_id.id:
+            account_id = self.product_id.property_account_income_id.id
+        if not account_id:
+            inc_acc = ir_property_obj.get('property_account_income_categ_id', 'product.category')
+            account_id = order.fiscal_position_id.map_account(inc_acc).id if inc_acc else False
+        if not account_id:
+            raise UserError(
+                _('There is no income account defined for this product: "%s". You may have to install a chart of account from Accounting app, settings menu.') % \
+                    (self.product_id.name,))
+
+        if self.amount <= 0.00:
+            raise UserError(_('The value of the down payment amount must be positive.'))
+        if self.advance_payment_method == 'percentage':
+            amount = order.amount_untaxed * self.amount / 100
+            name = _("Down payment of %s%%") % (self.amount,)
+        else:
+            amount = self.amount
+            name = _('Down Payment')
+        if order.fiscal_position_id and self.product_id.taxes_id:
+            tax_ids = order.fiscal_position_id.map_tax(self.product_id.taxes_id).ids
+        else:
+            tax_ids = self.product_id.taxes_id.ids
+
+        invoice = inv_obj.create({
+            'name': order.client_order_ref or order.name,
+            'origin': order.name,
+            'type': 'out_invoice',
+            'reference': False,
+            'account_id': order.partner_id.property_account_receivable_id.id,
+            'partner_id': order.partner_invoice_id.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': name,
+                'origin': order.name,
+                'account_id': account_id,
+                'price_unit': amount,
+                'quantity': 1.0,
+                'discount': 0.0,
+                'uom_id': self.product_id.uom_id.id,
+                'product_id': self.product_id.id,
+                'sale_line_ids': [(6, 0, [so_line.id])],
+                'invoice_line_tax_ids': [(6, 0, tax_ids)],
+                'account_analytic_id': order.project_id.id or False,
+            })],
+            'currency_id': order.pricelist_id.currency_id.id,
+            'payment_term_id': order.payment_term_id.id,
+            'fiscal_position_id': order.fiscal_position_id.id or order.partner_id.property_account_position_id.id,
+            'team_id': order.team_id.id,
+            'date_invoice': fields.Date.context_today(self),
+        })
+        invoice.compute_taxes()
+        return invoice


### PR DESCRIPTION
para la creación del objeto account.invoice contenga el campo
'date_invoice' ya que es requerido por la clase